### PR TITLE
CloudForecast::Data 以下の階層化

### DIFF
--- a/lib/CloudForecast/Host.pm
+++ b/lib/CloudForecast/Host.pm
@@ -72,7 +72,7 @@ sub load_data_module {
     my $self = shift;
     my $resource = shift;
 
-    $resource = ucfirst $resource;
+    $resource =~ s{([^_]+)|(_)}{$1 ? ucfirst $1 : $2 ? '::' : ''}egx;
     my $module = "CloudForecast::Data::" . $resource;
     $module->require or die $@;
     $module;


### PR DESCRIPTION
基本的にLinuxベースになっているようですので、別OS用などでも使いたいと思い、
load_data_moduleの中で、_(アンダーバー)    を '::' に置き換えるようにしてみました。

---

resources:
- solaris_basic
- solaris_memstat
- solaris_zpool:rpool 

loadしたいモジュール
CloudForecast::Data::Solaris::Basic
CloudForecast::Data::Solaris::Memtool
CloudForecast::Data::Solaris::Zpool

(githubを使うのが初めてので、使い方が変だったりしていたらすいません。)
