### PR TITLE
remove memShared in case of linux 2.6.

### DIFF
--- a/lib/CloudForecast/Data/Basic.pm
+++ b/lib/CloudForecast/Data/Basic.pm
@@ -1,6 +1,7 @@
 package CloudForecast::Data::Basic;
 
 use CloudForecast::Data -base;
+use Config;
 
 # RRDファイルを作成
 # [定義名,タイプ]
@@ -43,8 +44,13 @@ fetcher {
     #load
     push @map, [ 'laLoad', 1 ];
     # memory
-    push @map, map { [ $_, 0 ] } qw/memTotalSwap memAvailSwap memTotalReal memAvailReal memTotalFree 
+    if (lc($Config{osname}) eq 'linux' && $Config{osvers} =~ /^2\.6\./) {
+        push @map, map { [ $_, 0 ] } qw/memTotalSwap memAvailSwap memTotalReal memAvailReal memTotalFree 
+                            memBuffer memCached/;
+    } else {
+        push @map, map { [ $_, 0 ] } qw/memTotalSwap memAvailSwap memTotalReal memAvailReal memTotalFree 
                             memShared memBuffer memCached/;
+    }
     # tcp established
     push @map, [ 'tcpCurrEstab', 0 ];
 


### PR DESCRIPTION
"memShared" is no longer valid in Linux 2.6 kernel and dropped from
net-snmp.

http://sourceforge.net/tracker/index.php?func=detail&aid=3304076&group_id=12694&atid=112694
