### PR TITLE
hrstorage: s/hrStorage/hrStorageTable/

### DIFF
--- a/lib/CloudForecast/Data/Disk.pm
+++ b/lib/CloudForecast/Data/Disk.pm
@@ -16,7 +16,7 @@ title {
 sub hrstorage {
     my ($c,$interface) = @_;
     if ( $interface !~ /^\d+$/ ) {
-        my $disks = $c->component('SNMP')->table("hrStorage",
+        my $disks = $c->component('SNMP')->table("hrStorageTable",
             columns => [qw/hrStorageIndex hrStorageDescr hrStorageAllocationUnits hrStorageSize hrStorageUsed/] );
         if ( !$disks ) {
             CloudForecast::Log->debug("couldnot get htStorage, use dskTable");


### PR DESCRIPTION
cause following error:

```
***** ERROR parsing .1.3.6.1.2.1.25.2.3.1.1.6 MIB indexes:
  hrStorageIndex.6 => ARRAY
   [should be an ARRAY]
  expended # indexes = -1
***** ERROR parsing .1.3.6.1.2.1.25.2.3.1.1.6 MIB indexes: ARRAY -1 0
***** ERROR parsing .1.3.6.1.2.1.25.2.3.1.1.32 MIB indexes:
  hrStorageIndex.32 => ARRAY
   [should be an ARRAY]
  expended # indexes = -1
***** ERROR parsing .1.3.6.1.2.1.25.2.3.1.1.32 MIB indexes: ARRAY -1 0
...
```

I suppose "hrStorage" is not table structure.

See:
http://www.net-snmp.org/docs/mibs/host.html#treeview
