### PR TITLE
last_error may be undef, which leads to "Odd number of elements in anonymous hash"

### DIFF
--- a/lib/CloudForecast/Host.pm
+++ b/lib/CloudForecast/Host.pm
@@ -22,7 +22,7 @@ sub list_graph {
             resource => $resource,
             graphs => \@graphs,
             sysinfo => $data->graph_sysinfo,
-            last_error => $data->last_error,
+            last_error => $data->last_error || '',
         };
     }
     return @ret;


### PR DESCRIPTION
This is to fix the following warning from cloudforecast_web:

Odd number of elements in anonymous hash at /home/ishigaki/cloudforecast/lib/CloudForecast/Host.pm line 19, <DATA> line 70.
