### PR TITLE
use lt (or probably version module) as snmp version format is x.y.z

### DIFF
--- a/lib/CloudForecast/Data/Basic.pm
+++ b/lib/CloudForecast/Data/Basic.pm
@@ -21,7 +21,7 @@ graphs 'cpu' => 'CPU Usage [%]' => 'cpu.def', sub {
     my $sysinfo = $c->ledge_get('sysinfo') || [];
     my %sysinfo = @$sysinfo;
     my $version = $sysinfo{'snmp version'} || 0;
-    if ( $version < 5.4 ) {
+    if ( $version lt '5.4' ) {
         my $reader = Data::Section::Simple->new(ref $c);
         $template = $reader->get_data_section('cpu_old.def');
     } 


### PR DESCRIPTION
This is to fix the following warning from cloudforecast_web:

Argument "5.7.2" isn't numeric in numeric lt (<) at /home/ishigaki/cloudforecast/lib/CloudForecast/Data/Basic.pm line 25.
